### PR TITLE
Use Source Files directly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
                         <goals><goal>download-single</goal></goals>
                         <configuration>
                             <url>${dojo.url}</url>
-                            <fromFile>dojo-release-${dojo.version}.zip</fromFile>
+                            <fromFile>dojo-release-${dojo.version}-src.zip</fromFile>
                             <toFile>${project.build.directory}/dojo.zip</toFile>
                         </configuration>
                     </execution>
@@ -82,7 +82,7 @@
                                 <unzip src="${project.build.directory}/dojo.zip" dest="${project.build.directory}/dojo" />
                                 <echo message="moving resources" />
                                 <move todir="${destDir}" overwrite="true" verbose="true">
-                                    <fileset dir="${project.build.directory}/dojo/dojo-release-${dojo.version}" />
+                                    <fileset dir="${project.build.directory}/dojo/dojo-release-${dojo.version}-src" />
                                 </move>
                             </target>
                         </configuration>


### PR DESCRIPTION
In this way we can use Source Files directly instead using the compressed files. Furthermore the jar become smaller since you don't need uncompressed files any more.
